### PR TITLE
Media stored in S3 directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The main method expects the following arguments:
 
 For example:
 
-    sbt "run blog/_posts /tmp/ me@example.org mypassw0rd images.bucket xxx yyy"
+    sbt "runMain Main blog/_posts me@example.org mypassw0rd images.bucket xxx yyy"
 
 The subject is used as the title of the blog post and the filename.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ Reads an IMAP email account and writes JPEG attachments to the file system and c
 How use use
 -----------
 
-    sbt "run /path/to/my/blog me@example.org mypassw0rd"
+The main method expects the following arguments:
 
-This will connect to the me@example.org google email account, process emails, and write images to /path/to/my/blog/media and blog posts to /path/to/my/blog/_posts
+- path to write the markdown blog post to
+- Google email adrress
+- Address password
+- S3 bucket name
+- S3 key
+- S3 secret
+
+For example:
+
+    sbt "run blog/_posts /tmp/ me@example.org mypassw0rd images.bucket xxx yyy"
 
 The subject is used as the title of the blog post and the filename.
 
@@ -24,17 +33,9 @@ Run via cron, and wrapper in a script that either commits and pushes to your Git
 Known issues
 ------------
 
-* Images must be written to `/media/` on your blog
 * Only does JPEGs
 * Doesn't do video or sound files
-
-Prerequisites
--------------
-
-* SBT 0.11
-* Java (should work with 1.5; tested with 1.7)
 * Probably needs to be a Sun JVM
-
 
 License
 =======

--- a/build.sbt
+++ b/build.sbt
@@ -3,12 +3,14 @@ name := "telepost"
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies ++= Seq(
-  "org.scala-lang.modules" %% "scala-xml" % "1.0.4",
-  "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.3",
-  "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3",
-  "javax.mail" % "mail" % "1.4",
-  "org.imgscalr" % "imgscalr-lib" % "4.2",
-  "org.apache.sanselan" % "sanselan" % "0.97-incubator"
+  "org.scala-lang.modules"        %% "scala-xml"        % "1.0.4",
+  "com.github.scala-incubator.io" %% "scala-io-core"    % "0.4.3",
+  "com.github.scala-incubator.io" %% "scala-io-file"    % "0.4.3",
+  "javax.mail"                    % "mail"              % "1.4",
+  "org.imgscalr"                  % "imgscalr-lib"      % "4.2",
+  "com.amazonaws"                 % "aws-java-sdk-s3"   % "1.11.41",
+  "com.amazonaws"                 % "aws-java-sdk-core" % "1.11.41",
+  "org.apache.sanselan"           % "sanselan"          % "0.97-incubator"
 )
 
 // http://www.scala-sbt.org/0.13/docs/Forking.html
@@ -17,6 +19,6 @@ fork := true
 
 mainClass := Some("Main")
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.7
+sbt.version=0.13.12
 

--- a/src/main/scala/com/dallaway/telegram/email/BlogWriter.scala
+++ b/src/main/scala/com/dallaway/telegram/email/BlogWriter.scala
@@ -11,8 +11,7 @@ trait BlogWriter {
 
     val attachments = email.attachments.map(_.toHtml).mkString
 
-    val dateTime = new SimpleDateFormat("yyyy-MM-dd HH:mm").format(email.sentDate)
-    val date = new SimpleDateFormat("yyyy-MM-dd").format(email.sentDate)
+    val dateTime = new SimpleDateFormat("yyyy-MM-dd HH:mm").format(email.meta.sentDate)
 
     val blog =
       """|---
@@ -28,9 +27,10 @@ trait BlogWriter {
          |
          |%s
       """.stripMargin.format (
-        email.title, email.sender, dateTime, attachments, email.body)
+        email.meta.title, email.meta.sender, dateTime, attachments, email.body)
 
-    val filename = date + "-" + Hoisted.slugify(email.title) + ".md"
+    val date = new SimpleDateFormat("yyyy-MM-dd").format(email.meta.sentDate)
+    val filename = date + "-" + email.meta.slug + ".md"
 
     (postsDir / filename).write(blog)
 

--- a/src/main/scala/com/dallaway/telegram/email/EmailWriter.scala
+++ b/src/main/scala/com/dallaway/telegram/email/EmailWriter.scala
@@ -61,7 +61,7 @@ trait EmailWriter {
   }
 
   // Locate and extract each attachment in the email:
-  private def attachments(mediaDir: Path, m: Part, meta: EmailMeta) : Seq[Attachment] = m.getContent match {
+  private def attachments(mediaDir: Path, m: Part, meta: EmailMeta) : Seq[ImageAttachment] = m.getContent match {
 
     // * A body part attachment
     case p: MimeMultipart => for {
@@ -86,7 +86,7 @@ trait EmailWriter {
     in       : =>InputStream,
     mimeType : String,
     fileName : Clean
-  ): Option[Attachment] = {
+  ): Option[ImageAttachment] = {
 
     // - Save original image (to link to):
     val dest = mediaDir / fileName.fullName

--- a/src/main/scala/com/dallaway/telegram/email/Filenames.scala
+++ b/src/main/scala/com/dallaway/telegram/email/Filenames.scala
@@ -1,0 +1,27 @@
+package com.dallaway.telegram.email
+
+import java.text.SimpleDateFormat
+
+object Clean {
+  // Construct a cleaned-up attachement filename.
+  // E.g., 2016-10-08-hello-world-fullsize-IMG_266.jpg
+  def apply(raw: String, meta: EmailMeta): Clean = {
+    val name = raw.replace(' ', '_').replaceAllButLast('.', '_')
+    val date = new SimpleDateFormat("yyyy-MM-dd").format(meta.sentDate)
+    Clean(s"$date-${meta.slug}-fullsize-$name")
+  }
+
+  implicit class StringHelper(in: String) {
+    def replaceAllButLast(source: Char, dest: Char): String =
+      in.lastIndexOf(source) match {
+        case -1 => in
+        case n => in.substring(0,n).replace(source,dest) + in.substring(n)
+      }
+  }
+}
+
+case class Clean(fullName: String) {
+  // Convention for the thumbnail filename
+  def thumbName: String = fullName.replace("-fullsize-", "-thumb-")
+}
+

--- a/src/main/scala/com/dallaway/telegram/email/Imap.scala
+++ b/src/main/scala/com/dallaway/telegram/email/Imap.scala
@@ -5,7 +5,7 @@ import javax.mail._
 trait Imap {
 
   // Apply handler to each email found, returning the number of emails found
-  def checkMail(login: Credentials)(handler: javax.mail.Message => Unit): Int = {
+  def checkMail(login: ImapCredentials)(handler: javax.mail.Message => Unit): Int = {
 
     def withInbox[T](f: javax.mail.Folder ⇒ T) : T = {
       val props = new java.util.Properties

--- a/src/main/scala/com/dallaway/telegram/email/S3.scala
+++ b/src/main/scala/com/dallaway/telegram/email/S3.scala
@@ -1,0 +1,44 @@
+package com.dallaway.telegram.email
+
+import scala.util.Try
+import java.io.File
+import scalax.file.Path
+
+import com.amazonaws.auth.{AWSCredentials, BasicAWSCredentials}
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.{PutObjectRequest, CannedAccessControlList}
+
+object S3 {
+  def credentials(key: String, secret: String): AWSCredentials =
+    new BasicAWSCredentials(key, secret)
+}
+
+// We store images on S3.
+// An assumption here is that the URL is the same as the bucket name.
+case class S3(bucketName: String, credentials: AWSCredentials, mediaDir: Path) {
+
+  // Write the attachments (full and thumbnail) to S3.
+  // Return an EmailInfo value with the attachments updated to their URL on S3.
+  def putAttachments(email: EmailInfo): Try[EmailInfo] = Try {
+
+    val client = new AmazonS3Client(credentials)
+
+    def put(filename: String): Unit = {
+      val file = new File((mediaDir / filename).toAbsolute.path)
+      val req = new PutObjectRequest(bucketName, filename, file).withCannedAcl(CannedAccessControlList.PublicRead)
+      client.putObject(req)
+    }
+
+    val s3attachments = for {
+      a <- email.attachments
+      _  = put(a.fullUrlPath)
+      _  = put(a.inlineUrlPath)
+    } yield a.copy(
+        fullUrlPath   = s"http://$bucketName/${a.fullUrlPath}",
+        inlineUrlPath = s"http://$bucketName/${a.inlineUrlPath}"
+      )
+
+    email.copy(attachments = s3attachments)
+  }
+
+}

--- a/src/main/scala/com/dallaway/telegram/email/package.scala
+++ b/src/main/scala/com/dallaway/telegram/email/package.scala
@@ -15,21 +15,17 @@ case class EmailMeta(
 case class EmailInfo(
   meta        : EmailMeta,
   body        : String,
-  attachments : Seq[Attachment]
+  attachments : Seq[ImageAttachment]
 )
 
 case class ImageSize(width: Int, height: Int)
-
-abstract class Attachment(path: String, mimeType: String) {
-  def toHtml: NodeSeq
-}
 
 case class ImageAttachment(
   fullUrlPath   : String,
   inlineUrlPath : String,
   inlineSize    : ImageSize,
   mineType      : String
-) extends Attachment(fullUrlPath, mineType) {
+) {
   def toHtml =
       <div>
         <a href={fullUrlPath}>

--- a/src/main/scala/com/dallaway/telegram/email/package.scala
+++ b/src/main/scala/com/dallaway/telegram/email/package.scala
@@ -2,17 +2,21 @@ package com.dallaway.telegram.email
 
 import scala.xml.NodeSeq
 
-case class Credentials(username:String, password:String, host:String = "imap.gmail.com")
+case class ImapCredentials(username:String, password:String, host:String = "imap.gmail.com")
+
+case class EmailMeta(
+  sender      : String,
+  sentDate    : java.util.Date,
+  title       : String
+) {
+  lazy val slug = Hoisted.slugify(title)
+}
 
 case class EmailInfo(
-    sender:      String,
-    subject:     Option[String],
-    body:        String,
-    sentDate:    java.util.Date,
-    attachments: Seq[Attachment]) {
-
-  lazy val title = subject getOrElse body
-}
+  meta        : EmailMeta,
+  body        : String,
+  attachments : Seq[Attachment]
+)
 
 case class ImageSize(width: Int, height: Int)
 
@@ -20,7 +24,18 @@ abstract class Attachment(path: String, mimeType: String) {
   def toHtml: NodeSeq
 }
 
-case class ImageAttachment(fullUrlPath: String, inlineUrlPath: String, inlineSize: ImageSize, mineType: String) extends Attachment(fullUrlPath, mineType) {
+case class ImageAttachment(
+  fullUrlPath   : String,
+  inlineUrlPath : String,
+  inlineSize    : ImageSize,
+  mineType      : String
+) extends Attachment(fullUrlPath, mineType) {
   def toHtml =
-      <div><a href={fullUrlPath}><img src={inlineUrlPath} width={inlineSize.width.toString} height={inlineSize.height.toString}/></a></div>
+      <div>
+        <a href={fullUrlPath}>
+          <img src    = {inlineUrlPath}
+               width  = {inlineSize.width.toString}
+               height = {inlineSize.height.toString} />
+        </a>
+      </div>
 }


### PR DESCRIPTION
Both jekyll and hugo take many minutes to process the media/ directory of the blog.
This is mostly a cost of copying files around.  This PR solves this by directly storing the media into an S3 bucket, and referencing the bucket in the markdown of the blog post.
